### PR TITLE
Add missing src:alt_label prop

### DIFF
--- a/data/856/333/45/85633345-alt-quattroshapes.geojson
+++ b/data/856/333/45/85633345-alt-quattroshapes.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b450791f1b07411dcc681249a26ef1dc95ef0cad6e9d4a72d77cfab4fa082ea
-size 114532129
+oid sha256:021fc50c9437e675d50adef1b36165847f85aa6b999a101e478ddd8bc058fc79
+size 114532171


### PR DESCRIPTION
This PR adds a `src:alt_label` property to the New Zealand alt file stored in this repo. Git LFS is required (file is 109mb). No PIP work required, this simply updates properties.

**Number of records updated**: 1